### PR TITLE
Move callkeep changes from a nimble ape fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,7 @@ fastlane ios beta
 ```bash
 fastlane android beta
 ```
+
+### Patches
+
+We utilise the [patch-package](https://www.npmjs.com/package/patch-package) module in order to patch the `react-native-callkeep` module instead of maintaining a complete fork. See their README on how to make changes to the patch and how those patches get installed automatically within this project on install of npm modules.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -308,7 +308,7 @@ PODS:
     - ReactCommon/jscallinvoker (= 0.61.5)
   - ReactNativeIncallManager (3.2.3):
     - React
-  - RNCallKeep (3.0.13):
+  - RNCallKeep (4.0.1):
     - React
   - RNCAsyncStorage (1.8.0):
     - React
@@ -539,7 +539,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
   ReactNativeIncallManager: 155aa4612c0daa6e8f0af761b7b660aa6b13e20f
-  RNCallKeep: d2dc7821436e3eddfd51f9ec7e83b08e3bd80e2a
+  RNCallKeep: eac6e6b4892f1b1c2890a1ce6d5f5451d7543c57
   RNCAsyncStorage: 5d83b49070d41fd72906a116c5e7bdac4ea3a814
   RNCPushNotificationIOS: 4d9ffd08f00ef6c1029ebbf4d72fc711eca3ff01
   RNDeviceInfo: 6a3d16fce033f6979c4a6a41e62244d183e8c765
@@ -555,4 +555,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 3d499b79550f65e7db6085556cbc30ef8d39b6b2
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.10.0

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.6.3",
@@ -18,7 +19,7 @@
     "react": "16.9.0",
     "react-native": "0.61.5",
     "react-native-background-timer": "2.1.1",
-    "react-native-callkeep": "nimbleape/react-native-callkeep-1#aaf508332ff0855f500bd522779ef87884b59621",
+    "react-native-callkeep": "^4.0.1",
     "react-native-contacts": "^5.2.3",
     "react-native-debug": "^3.0.0",
     "react-native-deep-linking": "^2.2.0",
@@ -75,6 +76,8 @@
     "murmurhash-js": "^1.0.0",
     "node-sass": "^4.13.0",
     "notifyjs": "^3.0.0",
+    "patch-package": "^6.2.2",
+    "postinstall-postinstall": "^2.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-mixin": "^4.0.0",

--- a/patches/react-native-callkeep+4.0.1.patch
+++ b/patches/react-native-callkeep+4.0.1.patch
@@ -1,0 +1,662 @@
+diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/Constants.java b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/Constants.java
+index e0b8bc5..b48417a 100644
+--- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/Constants.java
++++ b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/Constants.java
+@@ -13,7 +13,7 @@ public class Constants {
+     public static final String ACTION_UNMUTE_CALL = "ACTION_UNMUTE_CALL";
+     public static final String ACTION_WAKE_APP = "ACTION_WAKE_APP";
+ 
+-    public static final String EXTRA_CALL_NUMBER = "EXTRA_CALL_NUMBER";
++    public static final String EXTRA_CALL_IDENTIFIER = "EXTRA_CALL_NUMBER";
+     public static final String EXTRA_CALL_UUID = "EXTRA_CALL_UUID";
+     public static final String EXTRA_CALLER_NAME = "EXTRA_CALLER_NAME";
+     // Can't use telecom.EXTRA_DISABLE_ADD_CALL ...
+diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepBackgroundMessagingService.java b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepBackgroundMessagingService.java
+index c069072..a1e49ce 100644
+--- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepBackgroundMessagingService.java
++++ b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepBackgroundMessagingService.java
+@@ -27,7 +27,7 @@ import com.facebook.react.bridge.Arguments;
+ import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+ 
+ import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
+-import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
++import static io.wazo.callkeep.Constants.EXTRA_CALL_IDENTIFIER;
+ import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
+ 
+ import javax.annotation.Nullable;
+diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+index 327d49b..7372350 100644
+--- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
++++ b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+@@ -44,6 +44,7 @@ import android.telecom.DisconnectCause;
+ import android.telecom.PhoneAccount;
+ import android.telecom.PhoneAccountHandle;
+ import android.telecom.TelecomManager;
++import android.telecom.VideoProfile;
+ import android.telephony.TelephonyManager;
+ import android.util.Log;
+ 
+@@ -73,7 +74,7 @@ import static androidx.core.app.ActivityCompat.requestPermissions;
+ 
+ import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
+ import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
+-import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
++import static io.wazo.callkeep.Constants.EXTRA_CALL_IDENTIFIER;
+ import static io.wazo.callkeep.Constants.ACTION_END_CALL;
+ import static io.wazo.callkeep.Constants.ACTION_ANSWER_CALL;
+ import static io.wazo.callkeep.Constants.ACTION_MUTE_CALL;
+@@ -155,20 +156,24 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
+     }
+ 
+     @ReactMethod
+-    public void displayIncomingCall(String uuid, String number, String callerName) {
++    public void displayIncomingCall(String uuid, String identifier, String callerType, boolean callHasVideo, String callerName) {
+         if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
+             return;
+         }
+ 
+-        Log.d(TAG, "displayIncomingCall number: " + number + ", callerName: " + callerName);
++        Log.d(TAG, "displayIncomingCall identifier: " + identifier + ", callerName: " + callerName + ", callerType: " + callerType + ", callHasVideo: " + callHasVideo);
+ 
+         Bundle extras = new Bundle();
+-        Uri uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, number, null);
++        Uri uri = Uri.fromParts((callerType.equals("sip") ? PhoneAccount.SCHEME_SIP : PhoneAccount.SCHEME_TEL), identifier, null);
+ 
+         extras.putParcelable(TelecomManager.EXTRA_INCOMING_CALL_ADDRESS, uri);
+         extras.putString(EXTRA_CALLER_NAME, callerName);
+         extras.putString(EXTRA_CALL_UUID, uuid);
+ 
++        if (callHasVideo) {
++            extras.putInt(TelecomManager.EXTRA_START_CALL_WITH_VIDEO_STATE, VideoProfile.STATE_BIDIRECTIONAL);
++        }
++
+         telecomManager.addNewIncomingCall(handle, extras);
+     }
+ 
+@@ -187,24 +192,28 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
+     }
+ 
+     @ReactMethod
+-    public void startCall(String uuid, String number, String callerName) {
+-        if (!isConnectionServiceAvailable() || !hasPhoneAccount() || !hasPermissions() || number == null) {
++    public void startCall(String uuid, String identifer, String callerName, String callerType, boolean callHasVideo) {
++        if (!isConnectionServiceAvailable() || !hasPhoneAccount() || !hasPermissions() || identifer == null) {
+             return;
+         }
+ 
+-        Log.d(TAG, "startCall number: " + number + ", callerName: " + callerName);
++        Log.d(TAG, "startCall identifer: " + identifer + ", callerName: " + callerName + ", callerType: " + callerType + ", callHasVideo: " + callHasVideo);
+ 
+         Bundle extras = new Bundle();
+-        Uri uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, number, null);
++        Uri uri = Uri.fromParts((callerType.equals("sip") ? PhoneAccount.SCHEME_SIP : PhoneAccount.SCHEME_TEL), identifer, null);
+ 
+         Bundle callExtras = new Bundle();
+         callExtras.putString(EXTRA_CALLER_NAME, callerName);
+         callExtras.putString(EXTRA_CALL_UUID, uuid);
+-        callExtras.putString(EXTRA_CALL_NUMBER, number);
++        callExtras.putString(EXTRA_CALL_IDENTIFIER, identifer);
+ 
+         extras.putParcelable(TelecomManager.EXTRA_PHONE_ACCOUNT_HANDLE, handle);
+         extras.putParcelable(TelecomManager.EXTRA_OUTGOING_CALL_EXTRAS, callExtras);
+ 
++        if (callHasVideo) {
++            extras.putInt(TelecomManager.EXTRA_INCOMING_VIDEO_STATE, VideoProfile.STATE_BIDIRECTIONAL);
++        }
++
+         telecomManager.placeCall(uri, extras);
+     }
+ 
+@@ -485,7 +494,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
+             return;
+         }
+ 
+-        conn.setConnectionCapabilities(conn.getConnectionCapabilities() | Connection.CAPABILITY_HOLD);
++        conn.setConnectionCapabilities(conn.getConnectionCapabilities());
+         conn.setActive();
+     }
+ 
+@@ -575,7 +584,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
+         String appName = this.getApplicationName(this.getAppContext());
+ 
+         PhoneAccount.Builder builder = new PhoneAccount.Builder(handle, appName)
+-                .setCapabilities(PhoneAccount.CAPABILITY_CALL_PROVIDER);
++                .addSupportedUriScheme(PhoneAccount.SCHEME_SIP)
++                .setCapabilities(PhoneAccount.CAPABILITY_CALL_PROVIDER | PhoneAccount.CAPABILITY_VIDEO_CALLING);
+ 
+         if (_settings != null && _settings.hasKey("imageName")) {
+             int identifier = appContext.getResources().getIdentifier(_settings.getString("imageName"), "drawable", appContext.getPackageName());
+@@ -700,7 +710,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
+                     sendEventToJS("RNCallKeepDidPerformDTMFAction", args);
+                     break;
+                 case ACTION_ONGOING_CALL:
+-                    args.putString("handle", attributeMap.get(EXTRA_CALL_NUMBER));
++                    args.putString("handle", attributeMap.get(EXTRA_CALL_IDENTIFIER));
+                     args.putString("callUUID", attributeMap.get(EXTRA_CALL_UUID));
+                     args.putString("name", attributeMap.get(EXTRA_CALLER_NAME));
+                     sendEventToJS("RNCallKeepDidReceiveStartCallAction", args);
+@@ -715,8 +725,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
+                     Intent headlessIntent = new Intent(reactContext, RNCallKeepBackgroundMessagingService.class);
+                     headlessIntent.putExtra("callUUID", attributeMap.get(EXTRA_CALL_UUID));
+                     headlessIntent.putExtra("name", attributeMap.get(EXTRA_CALLER_NAME));
+-                    headlessIntent.putExtra("handle", attributeMap.get(EXTRA_CALL_NUMBER));
+-                    Log.d(TAG, "wakeUpApplication: " + attributeMap.get(EXTRA_CALL_UUID) + ", number : " + attributeMap.get(EXTRA_CALL_NUMBER) + ", displayName:" + attributeMap.get(EXTRA_CALLER_NAME));
++                    headlessIntent.putExtra("handle", attributeMap.get(EXTRA_CALL_IDENTIFIER));
++                    Log.d(TAG, "wakeUpApplication: " + attributeMap.get(EXTRA_CALL_UUID) + ", number : " + attributeMap.get(EXTRA_CALL_IDENTIFIER) + ", displayName:" + attributeMap.get(EXTRA_CALLER_NAME));
+ 
+                     ComponentName name = reactContext.startService(headlessIntent);
+                     if (name != null) {
+diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnection.java b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+index 3deced5..3e4d44b 100644
+--- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
++++ b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+@@ -46,7 +46,7 @@ import static io.wazo.callkeep.Constants.ACTION_MUTE_CALL;
+ import static io.wazo.callkeep.Constants.ACTION_UNHOLD_CALL;
+ import static io.wazo.callkeep.Constants.ACTION_UNMUTE_CALL;
+ import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
+-import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
++import static io.wazo.callkeep.Constants.EXTRA_CALL_IDENTIFIER;
+ import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
+ 
+ @TargetApi(Build.VERSION_CODES.M)
+@@ -61,11 +61,11 @@ public class VoiceConnection extends Connection {
+         this.handle = handle;
+         this.context = context;
+ 
+-        String number = handle.get(EXTRA_CALL_NUMBER);
++        String identifier = handle.get(EXTRA_CALL_IDENTIFIER);
+         String name = handle.get(EXTRA_CALLER_NAME);
+ 
+-        if (number != null) {
+-            setAddress(Uri.parse(number), TelecomManager.PRESENTATION_ALLOWED);
++        if (identifier != null) {
++            setAddress(Uri.parse(identifier), TelecomManager.PRESENTATION_ALLOWED);
+         }
+         if (name != null && !name.equals("")) {
+             setCallerDisplayName(name, TelecomManager.PRESENTATION_ALLOWED);
+@@ -96,7 +96,7 @@ public class VoiceConnection extends Connection {
+         super.onAnswer();
+         Log.d(TAG, "onAnswer called");
+ 
+-        setConnectionCapabilities(getConnectionCapabilities() | Connection.CAPABILITY_HOLD);
++        setConnectionCapabilities(getConnectionCapabilities());
+         setAudioModeIsVoip(true);
+ 
+         sendCallRequestToActivity(ACTION_ANSWER_CALL, handle);
+diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+index aa83b53..91cbbe9 100644
+--- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
++++ b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+@@ -61,7 +61,7 @@ import static io.wazo.callkeep.Constants.ACTION_ONGOING_CALL;
+ import static io.wazo.callkeep.Constants.ACTION_CHECK_REACHABILITY;
+ import static io.wazo.callkeep.Constants.ACTION_WAKE_APP;
+ import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
+-import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
++import static io.wazo.callkeep.Constants.EXTRA_CALL_IDENTIFIER;
+ import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
+ import static io.wazo.callkeep.Constants.EXTRA_DISABLE_ADD_CALL;
+ import static io.wazo.callkeep.Constants.FOREGROUND_SERVICE_TYPE_MICROPHONE;
+@@ -138,7 +138,7 @@ public class VoiceConnectionService extends ConnectionService {
+     @Override
+     public Connection onCreateIncomingConnection(PhoneAccountHandle connectionManagerPhoneAccount, ConnectionRequest request) {
+         Bundle extra = request.getExtras();
+-        Uri number = request.getAddress();
++        Uri identifier = request.getAddress();
+         String name = extra.getString(EXTRA_CALLER_NAME);
+         Connection incomingCallConnection = createConnection(request);
+         incomingCallConnection.setRinging();
+@@ -166,27 +166,27 @@ public class VoiceConnectionService extends ConnectionService {
+     private Connection makeOutgoingCall(ConnectionRequest request, String uuid, Boolean forceWakeUp) {
+         Bundle extras = request.getExtras();
+         Connection outgoingCallConnection = null;
+-        String number = request.getAddress().getSchemeSpecificPart();
+-        String extrasNumber = extras.getString(EXTRA_CALL_NUMBER);
++        String identifier = request.getAddress().getSchemeSpecificPart();
++        String extrasIdentifier = extras.getString(EXTRA_CALL_IDENTIFIER);
+         String displayName = extras.getString(EXTRA_CALLER_NAME);
+         Boolean isForeground = VoiceConnectionService.isRunning(this.getApplicationContext());
+ 
+-        Log.d(TAG, "makeOutgoingCall:" + uuid + ", number: " + number + ", displayName:" + displayName);
++        Log.d(TAG, "makeOutgoingCall:" + uuid + ", identifier: " + identifier + ", displayName:" + displayName);
+ 
+         // Wakeup application if needed
+         if (!isForeground || forceWakeUp) {
+             Log.d(TAG, "onCreateOutgoingConnection: Waking up application");
+-            this.wakeUpApplication(uuid, number, displayName);
++            this.wakeUpApplication(uuid, identifier, displayName);
+         } else if (!this.canMakeOutgoingCall() && isReachable) {
+             Log.d(TAG, "onCreateOutgoingConnection: not available");
+             return Connection.createFailedConnection(new DisconnectCause(DisconnectCause.LOCAL));
+         }
+ 
+         // TODO: Hold all other calls
+-        if (extrasNumber == null || !extrasNumber.equals(number)) {
++        if (extrasIdentifier == null || !extrasIdentifier.equals(identifier)) {
+             extras.putString(EXTRA_CALL_UUID, uuid);
+             extras.putString(EXTRA_CALLER_NAME, displayName);
+-            extras.putString(EXTRA_CALL_NUMBER, number);
++            extras.putString(EXTRA_CALL_IDENTIFIER, identifier);
+         }
+ 
+         if (!canMakeMultipleCalls) {
+@@ -251,15 +251,15 @@ public class VoiceConnectionService extends ConnectionService {
+         startForeground(FOREGROUND_SERVICE_TYPE_MICROPHONE, notification);
+     }
+ 
+-    private void wakeUpApplication(String uuid, String number, String displayName) {
++    private void wakeUpApplication(String uuid, String identifier, String displayName) {
+         Intent headlessIntent = new Intent(
+             this.getApplicationContext(),
+             RNCallKeepBackgroundMessagingService.class
+         );
+         headlessIntent.putExtra("callUUID", uuid);
+         headlessIntent.putExtra("name", displayName);
+-        headlessIntent.putExtra("handle", number);
+-        Log.d(TAG, "wakeUpApplication: " + uuid + ", number : " + number + ", displayName:" + displayName);
++        headlessIntent.putExtra("handle", identifier);
++        Log.d(TAG, "wakeUpApplication: " + uuid + ", identifier : " + identifier + ", displayName:" + displayName);
+ 
+         ComponentName name = this.getApplicationContext().startService(headlessIntent);
+         if (name != null) {
+@@ -273,9 +273,9 @@ public class VoiceConnectionService extends ConnectionService {
+         }
+         Log.d(TAG, "checkReachability timeout, force wakeup");
+         Bundle extras = request.getExtras();
+-        String number = request.getAddress().getSchemeSpecificPart();
++        String identifier = request.getAddress().getSchemeSpecificPart();
+         String displayName = extras.getString(EXTRA_CALLER_NAME);
+-        wakeUpApplication(this.notReachableCallUuid, number, displayName);
++        wakeUpApplication(this.notReachableCallUuid, identifier, displayName);
+ 
+         VoiceConnectionService.currentConnectionRequest = null;
+     }
+@@ -301,9 +301,9 @@ public class VoiceConnectionService extends ConnectionService {
+     private Connection createConnection(ConnectionRequest request) {
+         Bundle extras = request.getExtras();
+         HashMap<String, String> extrasMap = this.bundleToMap(extras);
+-        extrasMap.put(EXTRA_CALL_NUMBER, request.getAddress().toString());
++        extrasMap.put(EXTRA_CALL_IDENTIFIER, request.getAddress().toString());
+         VoiceConnection connection = new VoiceConnection(this, extrasMap);
+-        connection.setConnectionCapabilities(Connection.CAPABILITY_MUTE | Connection.CAPABILITY_SUPPORT_HOLD);
++        connection.setConnectionCapabilities(Connection.CAPABILITY_MUTE);
+         connection.setInitializing();
+         connection.setExtras(extras);
+         currentConnections.put(extras.getString(EXTRA_CALL_UUID), connection);
+diff --git a/node_modules/react-native-callkeep/index.js b/node_modules/react-native-callkeep/index.js
+index 6ec6c20..27a6788 100644
+--- a/node_modules/react-native-callkeep/index.js
++++ b/node_modules/react-native-callkeep/index.js
+@@ -73,7 +73,7 @@ class RNCallKeep {
+ 
+   displayIncomingCall = (uuid, handle, localizedCallerName = '', handleType = 'number', hasVideo = false, options = null) => {
+     if (!isIOS) {
+-      RNCallKeepModule.displayIncomingCall(uuid, handle, localizedCallerName);
++      RNCallKeepModule.displayIncomingCall(uuid, handle, handleType, hasVideo, localizedCallerName);
+       return;
+     }
+ 
+@@ -94,7 +94,7 @@ class RNCallKeep {
+ 
+   startCall = (uuid, handle, contactIdentifier, handleType = 'number', hasVideo = false ) => {
+     if (!isIOS) {
+-      RNCallKeepModule.startCall(uuid, handle, contactIdentifier);
++      RNCallKeepModule.startCall(uuid, handle, contactIdentifier, handleType, hasVideo);
+       return;
+     }
+ 
+diff --git a/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m b/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
+index 04af403..f6caf24 100644
+--- a/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
++++ b/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
+@@ -285,7 +285,7 @@ + (void)initCallKitProvider {
+     NSLog(@"[RNCallKeep][updateDisplay] uuidString = %@ displayName = %@ uri = %@", uuidString, displayName, uri);
+ #endif
+     NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+-    CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:uri];
++    CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:uri];
+     CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
+     callUpdate.localizedCallerName = displayName;
+     callUpdate.remoteHandle = callHandle;
+@@ -511,7 +511,7 @@ + (CXProviderConfiguration *)getProviderConfiguration:(NSDictionary*)settings
+         int _handleType = [RNCallKeep getHandleType:settings[@"handleType"]];
+         providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:_handleType], nil];
+     }else{
+-        providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:CXHandleTypePhoneNumber], nil];
++        providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:CXHandleTypeGeneric], nil];
+     }
+     if (settings[@"supportsVideo"]) {
+         providerConfiguration.supportsVideo = [settings[@"supportsVideo"] boolValue];
+diff --git a/node_modules/react-native-callkeep/react-native-callkeep.patch b/node_modules/react-native-callkeep/react-native-callkeep.patch
+new file mode 100644
+index 0000000..f441e61
+--- /dev/null
++++ b/node_modules/react-native-callkeep/react-native-callkeep.patch
+@@ -0,0 +1,328 @@
++diff --git a/android/src/main/java/io/wazo/callkeep/Constants.java b/android/src/main/java/io/wazo/callkeep/Constants.java
++index e0b8bc5..b48417a 100644
++--- a/android/src/main/java/io/wazo/callkeep/Constants.java
+++++ b/android/src/main/java/io/wazo/callkeep/Constants.java
++@@ -13,7 +13,7 @@ public class Constants {
++     public static final String ACTION_UNMUTE_CALL = "ACTION_UNMUTE_CALL";
++     public static final String ACTION_WAKE_APP = "ACTION_WAKE_APP";
++ 
++-    public static final String EXTRA_CALL_NUMBER = "EXTRA_CALL_NUMBER";
+++    public static final String EXTRA_CALL_IDENTIFIER = "EXTRA_CALL_NUMBER";
++     public static final String EXTRA_CALL_UUID = "EXTRA_CALL_UUID";
++     public static final String EXTRA_CALLER_NAME = "EXTRA_CALLER_NAME";
++     // Can't use telecom.EXTRA_DISABLE_ADD_CALL ...
++diff --git a/android/src/main/java/io/wazo/callkeep/RNCallKeepBackgroundMessagingService.java b/android/src/main/java/io/wazo/callkeep/RNCallKeepBackgroundMessagingService.java
++index c069072..a1e49ce 100644
++--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepBackgroundMessagingService.java
+++++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepBackgroundMessagingService.java
++@@ -27,7 +27,7 @@ import com.facebook.react.bridge.Arguments;
++ import com.facebook.react.jstasks.HeadlessJsTaskConfig;
++ 
++ import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
++-import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
+++import static io.wazo.callkeep.Constants.EXTRA_CALL_IDENTIFIER;
++ import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
++ 
++ import javax.annotation.Nullable;
++diff --git a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
++index 327d49b..7372350 100644
++--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
++@@ -44,6 +44,7 @@ import android.telecom.DisconnectCause;
++ import android.telecom.PhoneAccount;
++ import android.telecom.PhoneAccountHandle;
++ import android.telecom.TelecomManager;
+++import android.telecom.VideoProfile;
++ import android.telephony.TelephonyManager;
++ import android.util.Log;
++ 
++@@ -73,7 +74,7 @@ import static androidx.core.app.ActivityCompat.requestPermissions;
++ 
++ import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
++ import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
++-import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
+++import static io.wazo.callkeep.Constants.EXTRA_CALL_IDENTIFIER;
++ import static io.wazo.callkeep.Constants.ACTION_END_CALL;
++ import static io.wazo.callkeep.Constants.ACTION_ANSWER_CALL;
++ import static io.wazo.callkeep.Constants.ACTION_MUTE_CALL;
++@@ -155,20 +156,24 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
++     }
++ 
++     @ReactMethod
++-    public void displayIncomingCall(String uuid, String number, String callerName) {
+++    public void displayIncomingCall(String uuid, String identifier, String callerType, boolean callHasVideo, String callerName) {
++         if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
++             return;
++         }
++ 
++-        Log.d(TAG, "displayIncomingCall number: " + number + ", callerName: " + callerName);
+++        Log.d(TAG, "displayIncomingCall identifier: " + identifier + ", callerName: " + callerName + ", callerType: " + callerType + ", callHasVideo: " + callHasVideo);
++ 
++         Bundle extras = new Bundle();
++-        Uri uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, number, null);
+++        Uri uri = Uri.fromParts((callerType.equals("sip") ? PhoneAccount.SCHEME_SIP : PhoneAccount.SCHEME_TEL), identifier, null);
++ 
++         extras.putParcelable(TelecomManager.EXTRA_INCOMING_CALL_ADDRESS, uri);
++         extras.putString(EXTRA_CALLER_NAME, callerName);
++         extras.putString(EXTRA_CALL_UUID, uuid);
++ 
+++        if (callHasVideo) {
+++            extras.putInt(TelecomManager.EXTRA_START_CALL_WITH_VIDEO_STATE, VideoProfile.STATE_BIDIRECTIONAL);
+++        }
+++
++         telecomManager.addNewIncomingCall(handle, extras);
++     }
++ 
++@@ -187,24 +192,28 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
++     }
++ 
++     @ReactMethod
++-    public void startCall(String uuid, String number, String callerName) {
++-        if (!isConnectionServiceAvailable() || !hasPhoneAccount() || !hasPermissions() || number == null) {
+++    public void startCall(String uuid, String identifer, String callerName, String callerType, boolean callHasVideo) {
+++        if (!isConnectionServiceAvailable() || !hasPhoneAccount() || !hasPermissions() || identifer == null) {
++             return;
++         }
++ 
++-        Log.d(TAG, "startCall number: " + number + ", callerName: " + callerName);
+++        Log.d(TAG, "startCall identifer: " + identifer + ", callerName: " + callerName + ", callerType: " + callerType + ", callHasVideo: " + callHasVideo);
++ 
++         Bundle extras = new Bundle();
++-        Uri uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, number, null);
+++        Uri uri = Uri.fromParts((callerType.equals("sip") ? PhoneAccount.SCHEME_SIP : PhoneAccount.SCHEME_TEL), identifer, null);
++ 
++         Bundle callExtras = new Bundle();
++         callExtras.putString(EXTRA_CALLER_NAME, callerName);
++         callExtras.putString(EXTRA_CALL_UUID, uuid);
++-        callExtras.putString(EXTRA_CALL_NUMBER, number);
+++        callExtras.putString(EXTRA_CALL_IDENTIFIER, identifer);
++ 
++         extras.putParcelable(TelecomManager.EXTRA_PHONE_ACCOUNT_HANDLE, handle);
++         extras.putParcelable(TelecomManager.EXTRA_OUTGOING_CALL_EXTRAS, callExtras);
++ 
+++        if (callHasVideo) {
+++            extras.putInt(TelecomManager.EXTRA_INCOMING_VIDEO_STATE, VideoProfile.STATE_BIDIRECTIONAL);
+++        }
+++
++         telecomManager.placeCall(uri, extras);
++     }
++ 
++@@ -485,7 +494,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
++             return;
++         }
++ 
++-        conn.setConnectionCapabilities(conn.getConnectionCapabilities() | Connection.CAPABILITY_HOLD);
+++        conn.setConnectionCapabilities(conn.getConnectionCapabilities());
++         conn.setActive();
++     }
++ 
++@@ -575,7 +584,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
++         String appName = this.getApplicationName(this.getAppContext());
++ 
++         PhoneAccount.Builder builder = new PhoneAccount.Builder(handle, appName)
++-                .setCapabilities(PhoneAccount.CAPABILITY_CALL_PROVIDER);
+++                .addSupportedUriScheme(PhoneAccount.SCHEME_SIP)
+++                .setCapabilities(PhoneAccount.CAPABILITY_CALL_PROVIDER | PhoneAccount.CAPABILITY_VIDEO_CALLING);
++ 
++         if (_settings != null && _settings.hasKey("imageName")) {
++             int identifier = appContext.getResources().getIdentifier(_settings.getString("imageName"), "drawable", appContext.getPackageName());
++@@ -700,7 +710,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
++                     sendEventToJS("RNCallKeepDidPerformDTMFAction", args);
++                     break;
++                 case ACTION_ONGOING_CALL:
++-                    args.putString("handle", attributeMap.get(EXTRA_CALL_NUMBER));
+++                    args.putString("handle", attributeMap.get(EXTRA_CALL_IDENTIFIER));
++                     args.putString("callUUID", attributeMap.get(EXTRA_CALL_UUID));
++                     args.putString("name", attributeMap.get(EXTRA_CALLER_NAME));
++                     sendEventToJS("RNCallKeepDidReceiveStartCallAction", args);
++@@ -715,8 +725,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
++                     Intent headlessIntent = new Intent(reactContext, RNCallKeepBackgroundMessagingService.class);
++                     headlessIntent.putExtra("callUUID", attributeMap.get(EXTRA_CALL_UUID));
++                     headlessIntent.putExtra("name", attributeMap.get(EXTRA_CALLER_NAME));
++-                    headlessIntent.putExtra("handle", attributeMap.get(EXTRA_CALL_NUMBER));
++-                    Log.d(TAG, "wakeUpApplication: " + attributeMap.get(EXTRA_CALL_UUID) + ", number : " + attributeMap.get(EXTRA_CALL_NUMBER) + ", displayName:" + attributeMap.get(EXTRA_CALLER_NAME));
+++                    headlessIntent.putExtra("handle", attributeMap.get(EXTRA_CALL_IDENTIFIER));
+++                    Log.d(TAG, "wakeUpApplication: " + attributeMap.get(EXTRA_CALL_UUID) + ", number : " + attributeMap.get(EXTRA_CALL_IDENTIFIER) + ", displayName:" + attributeMap.get(EXTRA_CALLER_NAME));
++ 
++                     ComponentName name = reactContext.startService(headlessIntent);
++                     if (name != null) {
++diff --git a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
++index 3deced5..3e4d44b 100644
++--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
++@@ -46,7 +46,7 @@ import static io.wazo.callkeep.Constants.ACTION_MUTE_CALL;
++ import static io.wazo.callkeep.Constants.ACTION_UNHOLD_CALL;
++ import static io.wazo.callkeep.Constants.ACTION_UNMUTE_CALL;
++ import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
++-import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
+++import static io.wazo.callkeep.Constants.EXTRA_CALL_IDENTIFIER;
++ import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
++ 
++ @TargetApi(Build.VERSION_CODES.M)
++@@ -61,11 +61,11 @@ public class VoiceConnection extends Connection {
++         this.handle = handle;
++         this.context = context;
++ 
++-        String number = handle.get(EXTRA_CALL_NUMBER);
+++        String identifier = handle.get(EXTRA_CALL_IDENTIFIER);
++         String name = handle.get(EXTRA_CALLER_NAME);
++ 
++-        if (number != null) {
++-            setAddress(Uri.parse(number), TelecomManager.PRESENTATION_ALLOWED);
+++        if (identifier != null) {
+++            setAddress(Uri.parse(identifier), TelecomManager.PRESENTATION_ALLOWED);
++         }
++         if (name != null && !name.equals("")) {
++             setCallerDisplayName(name, TelecomManager.PRESENTATION_ALLOWED);
++@@ -96,7 +96,7 @@ public class VoiceConnection extends Connection {
++         super.onAnswer();
++         Log.d(TAG, "onAnswer called");
++ 
++-        setConnectionCapabilities(getConnectionCapabilities() | Connection.CAPABILITY_HOLD);
+++        setConnectionCapabilities(getConnectionCapabilities());
++         setAudioModeIsVoip(true);
++ 
++         sendCallRequestToActivity(ACTION_ANSWER_CALL, handle);
++diff --git a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
++index aa83b53..91cbbe9 100644
++--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
++@@ -61,7 +61,7 @@ import static io.wazo.callkeep.Constants.ACTION_ONGOING_CALL;
++ import static io.wazo.callkeep.Constants.ACTION_CHECK_REACHABILITY;
++ import static io.wazo.callkeep.Constants.ACTION_WAKE_APP;
++ import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
++-import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
+++import static io.wazo.callkeep.Constants.EXTRA_CALL_IDENTIFIER;
++ import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
++ import static io.wazo.callkeep.Constants.EXTRA_DISABLE_ADD_CALL;
++ import static io.wazo.callkeep.Constants.FOREGROUND_SERVICE_TYPE_MICROPHONE;
++@@ -138,7 +138,7 @@ public class VoiceConnectionService extends ConnectionService {
++     @Override
++     public Connection onCreateIncomingConnection(PhoneAccountHandle connectionManagerPhoneAccount, ConnectionRequest request) {
++         Bundle extra = request.getExtras();
++-        Uri number = request.getAddress();
+++        Uri identifier = request.getAddress();
++         String name = extra.getString(EXTRA_CALLER_NAME);
++         Connection incomingCallConnection = createConnection(request);
++         incomingCallConnection.setRinging();
++@@ -166,27 +166,27 @@ public class VoiceConnectionService extends ConnectionService {
++     private Connection makeOutgoingCall(ConnectionRequest request, String uuid, Boolean forceWakeUp) {
++         Bundle extras = request.getExtras();
++         Connection outgoingCallConnection = null;
++-        String number = request.getAddress().getSchemeSpecificPart();
++-        String extrasNumber = extras.getString(EXTRA_CALL_NUMBER);
+++        String identifier = request.getAddress().getSchemeSpecificPart();
+++        String extrasIdentifier = extras.getString(EXTRA_CALL_IDENTIFIER);
++         String displayName = extras.getString(EXTRA_CALLER_NAME);
++         Boolean isForeground = VoiceConnectionService.isRunning(this.getApplicationContext());
++ 
++-        Log.d(TAG, "makeOutgoingCall:" + uuid + ", number: " + number + ", displayName:" + displayName);
+++        Log.d(TAG, "makeOutgoingCall:" + uuid + ", identifier: " + identifier + ", displayName:" + displayName);
++ 
++         // Wakeup application if needed
++         if (!isForeground || forceWakeUp) {
++             Log.d(TAG, "onCreateOutgoingConnection: Waking up application");
++-            this.wakeUpApplication(uuid, number, displayName);
+++            this.wakeUpApplication(uuid, identifier, displayName);
++         } else if (!this.canMakeOutgoingCall() && isReachable) {
++             Log.d(TAG, "onCreateOutgoingConnection: not available");
++             return Connection.createFailedConnection(new DisconnectCause(DisconnectCause.LOCAL));
++         }
++ 
++         // TODO: Hold all other calls
++-        if (extrasNumber == null || !extrasNumber.equals(number)) {
+++        if (extrasIdentifier == null || !extrasIdentifier.equals(identifier)) {
++             extras.putString(EXTRA_CALL_UUID, uuid);
++             extras.putString(EXTRA_CALLER_NAME, displayName);
++-            extras.putString(EXTRA_CALL_NUMBER, number);
+++            extras.putString(EXTRA_CALL_IDENTIFIER, identifier);
++         }
++ 
++         if (!canMakeMultipleCalls) {
++@@ -251,15 +251,15 @@ public class VoiceConnectionService extends ConnectionService {
++         startForeground(FOREGROUND_SERVICE_TYPE_MICROPHONE, notification);
++     }
++ 
++-    private void wakeUpApplication(String uuid, String number, String displayName) {
+++    private void wakeUpApplication(String uuid, String identifier, String displayName) {
++         Intent headlessIntent = new Intent(
++             this.getApplicationContext(),
++             RNCallKeepBackgroundMessagingService.class
++         );
++         headlessIntent.putExtra("callUUID", uuid);
++         headlessIntent.putExtra("name", displayName);
++-        headlessIntent.putExtra("handle", number);
++-        Log.d(TAG, "wakeUpApplication: " + uuid + ", number : " + number + ", displayName:" + displayName);
+++        headlessIntent.putExtra("handle", identifier);
+++        Log.d(TAG, "wakeUpApplication: " + uuid + ", identifier : " + identifier + ", displayName:" + displayName);
++ 
++         ComponentName name = this.getApplicationContext().startService(headlessIntent);
++         if (name != null) {
++@@ -273,9 +273,9 @@ public class VoiceConnectionService extends ConnectionService {
++         }
++         Log.d(TAG, "checkReachability timeout, force wakeup");
++         Bundle extras = request.getExtras();
++-        String number = request.getAddress().getSchemeSpecificPart();
+++        String identifier = request.getAddress().getSchemeSpecificPart();
++         String displayName = extras.getString(EXTRA_CALLER_NAME);
++-        wakeUpApplication(this.notReachableCallUuid, number, displayName);
+++        wakeUpApplication(this.notReachableCallUuid, identifier, displayName);
++ 
++         VoiceConnectionService.currentConnectionRequest = null;
++     }
++@@ -301,9 +301,9 @@ public class VoiceConnectionService extends ConnectionService {
++     private Connection createConnection(ConnectionRequest request) {
++         Bundle extras = request.getExtras();
++         HashMap<String, String> extrasMap = this.bundleToMap(extras);
++-        extrasMap.put(EXTRA_CALL_NUMBER, request.getAddress().toString());
+++        extrasMap.put(EXTRA_CALL_IDENTIFIER, request.getAddress().toString());
++         VoiceConnection connection = new VoiceConnection(this, extrasMap);
++-        connection.setConnectionCapabilities(Connection.CAPABILITY_MUTE | Connection.CAPABILITY_SUPPORT_HOLD);
+++        connection.setConnectionCapabilities(Connection.CAPABILITY_MUTE);
++         connection.setInitializing();
++         connection.setExtras(extras);
++         currentConnections.put(extras.getString(EXTRA_CALL_UUID), connection);
++diff --git a/index.js b/index.js
++index 6ec6c20..27a6788 100644
++--- a/index.js
+++++ b/index.js
++@@ -73,7 +73,7 @@ class RNCallKeep {
++ 
++   displayIncomingCall = (uuid, handle, localizedCallerName = '', handleType = 'number', hasVideo = false, options = null) => {
++     if (!isIOS) {
++-      RNCallKeepModule.displayIncomingCall(uuid, handle, localizedCallerName);
+++      RNCallKeepModule.displayIncomingCall(uuid, handle, handleType, hasVideo, localizedCallerName);
++       return;
++     }
++ 
++@@ -94,7 +94,7 @@ class RNCallKeep {
++ 
++   startCall = (uuid, handle, contactIdentifier, handleType = 'number', hasVideo = false ) => {
++     if (!isIOS) {
++-      RNCallKeepModule.startCall(uuid, handle, contactIdentifier);
+++      RNCallKeepModule.startCall(uuid, handle, contactIdentifier, handleType, hasVideo);
++       return;
++     }
++ 
++diff --git a/ios/RNCallKeep/RNCallKeep.m b/ios/RNCallKeep/RNCallKeep.m
++index 04af403..f6caf24 100644
++--- a/ios/RNCallKeep/RNCallKeep.m
+++++ b/ios/RNCallKeep/RNCallKeep.m
++@@ -285,7 +285,7 @@ RCT_EXPORT_METHOD(updateDisplay:(NSString *)uuidString :(NSString *)displayName
++     NSLog(@"[RNCallKeep][updateDisplay] uuidString = %@ displayName = %@ uri = %@", uuidString, displayName, uri);
++ #endif
++     NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
++-    CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:uri];
+++    CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:uri];
++     CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
++     callUpdate.localizedCallerName = displayName;
++     callUpdate.remoteHandle = callHandle;
++@@ -511,7 +511,7 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
++         int _handleType = [RNCallKeep getHandleType:settings[@"handleType"]];
++         providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:_handleType], nil];
++     }else{
++-        providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:CXHandleTypePhoneNumber], nil];
+++        providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:CXHandleTypeGeneric], nil];
++     }
++     if (settings[@"supportsVideo"]) {
++         providerConfiguration.supportsVideo = [settings[@"supportsVideo"] boolValue];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,6 +1171,11 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 JSONStream@^1.0.3:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -3922,6 +3927,14 @@ find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 flat-cache@^1.2.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.4.tgz#2c2ef77525cc2929007dfffa1dd314aa9c9dee6f"
@@ -4031,6 +4044,15 @@ fs-extra@^3.0.1:
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
     universalify "^0.1.0"
 
 fs-extra@^7.0.1:
@@ -5648,6 +5670,13 @@ kind-of@^6.0.0, kind-of@^6.0.1, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -7040,6 +7069,24 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+patch-package@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.2.tgz#71d170d650c65c26556f0d0fbbb48d92b6cc5f39"
+  integrity sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+
 path-browserify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
@@ -7223,6 +7270,11 @@ postcss-value-parser@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
+
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -7465,9 +7517,10 @@ react-native-background-timer@2.1.1:
   resolved "https://registry.yarnpkg.com/react-native-background-timer/-/react-native-background-timer-2.1.1.tgz#9a2489681ab2f8033c213c73272e9d4c47572cd5"
   integrity sha512-cuXIIv+dcG8a8qkTD8pMzeqOEZCO+UGKglZWIe1osve+yJslmCowYQff+bI9xa7NOt2w+Vtd4L3d9JonlSqODg==
 
-react-native-callkeep@nimbleape/react-native-callkeep-1#aaf508332ff0855f500bd522779ef87884b59621:
-  version "3.0.13"
-  resolved "https://codeload.github.com/nimbleape/react-native-callkeep-1/tar.gz/aaf508332ff0855f500bd522779ef87884b59621"
+react-native-callkeep@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-callkeep/-/react-native-callkeep-4.0.1.tgz#533e0b8a0cf0ebe4600c5e3186ee324deb24cee1"
+  integrity sha512-TCzIL4Yc8yGqhk84tQW8BAFuoiNNC64J2fkyMFfKd/sDGvIKveEC/JvzzgmMMibQY9J85ful64FyWuvGU1XODw==
 
 react-native-contacts@^5.2.3:
   version "5.2.3"


### PR DESCRIPTION
Instead we use the patch-package module in order to keep the changes locally inside this repo so that we're not maintaining a complete fork  - allowing us to update which version of callkeep we're using with minimal upkeep.